### PR TITLE
fix vertical height to 100%

### DIFF
--- a/example/static/css/specviz.css
+++ b/example/static/css/specviz.css
@@ -128,6 +128,7 @@ td[alt]:hover:after {
 .notebook-container {
     margin-left: auto;
     margin-right: auto;
+    margin-top: -25px;
 }
 
 .search-bar-text input {
@@ -211,4 +212,8 @@ main.v-content.search-bar-container {
     cursor: pointer;
     width: 60px;
     height: calc(100vh - 128px);
+}
+
+.jdaviz {
+  height: 100vh !important;
 }


### PR DESCRIPTION
* avoids expanding plugin panel from overflowing past window height
* bumps up the top of jdaviz to the same level as the left panel and avoids the xlabels on the plot from overflowing because of the margin/padding. 